### PR TITLE
Fix hassfest translation URL validation errors

### DIFF
--- a/custom_components/ims_envista/config_flow.py
+++ b/custom_components/ims_envista/config_flow.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from ims_envista.station_data import StationInfo
 
 MIN_DISTANCE_TO_STATION_FOR_AUTOSELECT = 10
+OBSERVATION_API_DOCS_URL = "https://ims.gov.il/en/ObservationDataAPI"
 
 
 def _find_closest_station(
@@ -139,6 +140,7 @@ class BlueprintFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                 },
             ),
+            description_placeholders={"docs_url": OBSERVATION_API_DOCS_URL},
             errors=_errors,
         )
 
@@ -227,5 +229,6 @@ class BlueprintFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ): cv.multi_select(monitor_options),
                 },
             ),
+            description_placeholders={"docs_url": OBSERVATION_API_DOCS_URL},
             errors=_errors,
         )

--- a/custom_components/ims_envista/translations/ar.json
+++ b/custom_components/ims_envista/translations/ar.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "أدخل مفتاحاتبع التعليمات الموجودة على https://ims.gov.il/ar/ObservationDataAPI للحصول على مفتاح API",
+        "description": "أدخل مفتاحاتبع التعليمات الموجودة على {docs_url} للحصول على مفتاح API",
         "data": {
           "api_token": "API Token"
         }
@@ -14,7 +14,7 @@
         }
       },
       "select_station_conditions": {
-        "description": "حدد الشروط لتتبعها. يمكنك قراءة المزيد على https://ims.gov.il/ar/ObservationDataAPI",
+        "description": "حدد الشروط لتتبعها. يمكنك قراءة المزيد على {docs_url}",
         "data": {
           "station_conditions": "شروط"
         }

--- a/custom_components/ims_envista/translations/en.json
+++ b/custom_components/ims_envista/translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "step": {
             "user": {
-                "description": "Follow the instructions at https://ims.gov.il/en/ObservationDataAPI to obtain an API key",
+                "description": "Follow the instructions at {docs_url} to obtain an API key",
                 "data": {
                     "api_token": "API Token"
                 }
@@ -14,7 +14,7 @@
                 }
             },
             "select_station_conditions": {
-                "description": "Select monitoring station's conditions. You can read more at https://ims.gov.il/en/ObservationDataAPI",
+                "description": "Select monitoring station's conditions. You can read more at {docs_url}",
                 "data": {
                     "station_conditions": "Conditions"
                 }

--- a/custom_components/ims_envista/translations/he.json
+++ b/custom_components/ims_envista/translations/he.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "עקוב אחרי ההנחיות ב-https://ims.gov.il/he/ObservationDataAPI לקבלת מפתח API",
+        "description": "עקוב אחרי ההנחיות ב-{docs_url} לקבלת מפתח API",
         "data": {
           "api_token": "מפתח API"
         }
@@ -14,7 +14,7 @@
         }
       },
       "select_station_conditions": {
-        "description": "בחר תנאים למעקב. תוכל לקרוא עוד ב https://ims.gov.il/he/ObservationDataAPI",
+        "description": "בחר תנאים למעקב. תוכל לקרוא עוד ב {docs_url}",
         "data": {
           "station_conditions": "תנאים"
         }


### PR DESCRIPTION
## Summary
- replace hardcoded documentation URLs in translation descriptions with {docs_url} placeholders
- pass description_placeholders from config flow for affected steps
- update English, Arabic, and Hebrew translations to keep behavior consistent

## Verification
- rg -n "\"description\"\s*:\s*\".*https?://" custom_components/ims_envista/translations/*.json (no matches)
- python -m json.tool custom_components/ims_envista/translations/en.json
- python -m json.tool custom_components/ims_envista/translations/ar.json
- python -m json.tool custom_components/ims_envista/translations/he.json

Note: local python -m script.hassfest is not available in this environment; CI hassfest should validate this end-to-end.