### PR TITLE
Add mypy validations with type fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,22 @@ jobs:
 
         - name: "Format"
           run: python3 -m ruff format . --check
+
+  mypy:
+    name: "Mypy"
+    runs-on: "ubuntu-latest"
+    steps:
+        - name: "Checkout the repository"
+          uses: "actions/checkout@v6.0.2"
+
+        - name: "Set up Python"
+          uses: actions/setup-python@v6.2.0
+          with:
+            python-version: "3.12"
+            cache: "pip"
+
+        - name: "Install requirements"
+          run: python3 -m pip install -r requirements.txt
+
+        - name: "Type check"
+          run: ./scripts/typecheck

--- a/custom_components/ims_envista/__init__.py
+++ b/custom_components/ims_envista/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -39,7 +39,7 @@ async def async_setup_entry(
     """Set up this integration using UI."""
     coordinator = ImsEnvistaUpdateCoordinator(hass=hass, config_entry=entry)
 
-    entry.runtime_data = ImsEnvistaData(
+    entry_data = ImsEnvistaData(
         client=IMSEnvista(
             token=entry.data[CONF_API_TOKEN],
             session=async_get_clientsession(hass),
@@ -49,7 +49,7 @@ async def async_setup_entry(
         station_id=entry.data[CONF_STATION_ID],
         conditions=entry.data[CONF_STATION_CONDITIONS],
     )
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.runtime_data
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
 
     await coordinator.add_station(entry.data[CONF_STATION_ID])
 
@@ -64,9 +64,11 @@ async def async_setup_entry(
         async def handle_debug_get_coordinator_data(call: ServiceCall) -> None:  # noqa: ARG001
             """Log coordinator data for all loaded IMS Envista entries."""
             data = {
-                config_entry.entry_id: config_entry.runtime_data.coordinator.data
+                config_entry.entry_id: cast(
+                    "ImsEnvistaData", hass.data[DOMAIN][config_entry.entry_id]
+                ).coordinator.data
                 for config_entry in hass.config_entries.async_entries(DOMAIN)
-                if config_entry.runtime_data is not None
+                if config_entry.entry_id in hass.data.get(DOMAIN, {})
             }
             LOGGER.info("Coordinator data: %s", data)
             hass.bus.async_fire("custom_component_debug_event", {"data": data})

--- a/custom_components/ims_envista/config_flow.py
+++ b/custom_components/ims_envista/config_flow.py
@@ -75,13 +75,13 @@ def _find_closest_station(
         return stations[0] if len(stations) > 0 else None
     LOGGER.debug(
         "Closest station is: %s - %s km",
-        closest_station.name,
+        closest_station.name if closest_station else "None",
         round(closest_distance, 2),
     )
     return closest_station
 
 
-class ImsEnvistaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class ImsEnvistaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Config flow for IMS Envista."""
 
     VERSION = 1
@@ -107,7 +107,7 @@ class ImsEnvistaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_input: dict | None = None,
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by the user."""
-        _errors = {}
+        _errors: dict[str, str] = {}
         if user_input is not None:
             token = user_input[CONF_API_TOKEN]
             try:
@@ -170,7 +170,7 @@ class ImsEnvistaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._stations is None:
             return self.async_abort(reason="unknown")
 
-        _errors = {}
+        _errors: dict[str, str] = {}
         if user_input is not None and user_input[CONF_STATION]:
             selected_station = next(
                 filter(
@@ -178,7 +178,7 @@ class ImsEnvistaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 None,
             )
-            if selected_station:
+            if selected_station is not None:
                 LOGGER.debug("Selected Station is: %s", selected_station.name)
                 self._selected_station = selected_station
                 return await self.async_step_select_station_conditions()
@@ -204,7 +204,8 @@ class ImsEnvistaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_STATION, default=closest_station.station_id
+                        CONF_STATION,
+                        default=closest_station.station_id if closest_station else None,
                     ): vol.In(station_options),
                 },
             ),
@@ -219,7 +220,7 @@ class ImsEnvistaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._selected_station is None:
             return self.async_abort(reason="unknown")
 
-        _errors = {}
+        _errors: dict[str, str] = {}
         if user_input is not None and CONF_STATION_CONDITIONS in user_input:
             selected_conditions = [
                 WS_10MM_CHANNEL if condition == WS_10MM_LEGACY_CHANNEL else condition

--- a/custom_components/ims_envista/coordinator.py
+++ b/custom_components/ims_envista/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from ims_envista.station_data import StationInfo
 
-    from .data import ImsEnvistaConfigEntry
+    from .data import ImsEnvistaConfigEntry, ImsEnvistaData
 
 
 # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
@@ -35,9 +35,10 @@ class ImsEnvistaUpdateCoordinator(DataUpdateCoordinator):
             )
             return False
         try:
-            station_info = await self.config_entry.runtime_data.client.get_station_info(
-                station_id
+            entry_data = cast(
+                "ImsEnvistaData", self.hass.data[DOMAIN][self.config_entry.entry_id]
             )
+            station_info = await entry_data.client.get_station_info(station_id)
             self._stations_static_data[station_id] = station_info
         except ImsEnvistaApiClientError as exception:
             LOGGER.error("Error getting station info: %s", exception)
@@ -46,16 +47,16 @@ class ImsEnvistaUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize."""
-        self._stations = []
-        self._stations_static_data = {}
+        self._stations: list[int] = []
+        self._stations_static_data: dict[int, StationInfo] = {}
 
         super().__init__(
             hass=hass,
             logger=LOGGER,
-            config_entry=config_entry,
             name=DOMAIN,
             update_interval=timedelta(minutes=10),
         )
+        self.config_entry = config_entry
 
     async def add_station(self, station_id: int) -> None:
         """Add station."""
@@ -81,18 +82,19 @@ class ImsEnvistaUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error("Missing station %s data in coordinator", station_id)
         return station_info
 
-    async def _async_update_data(self) -> Any:
+    async def _async_update_data(self) -> dict[int, dict[str, Any]]:
         """Update data via library."""
-        station_data = {}
+        station_data: dict[int, dict[str, Any]] = {}
         try:
             for station in self._stations:
                 LOGGER.debug("Updating Station %d", station)
                 station_data[station] = station_data.get(station, {})
 
-                station_latest_res = (
-                    await self.config_entry.runtime_data.client.get_latest_station_data(
-                        station
-                    )
+                entry_data = cast(
+                    "ImsEnvistaData", self.hass.data[DOMAIN][self.config_entry.entry_id]
+                )
+                station_latest_res = await entry_data.client.get_latest_station_data(
+                    station
                 )
 
                 station_latest = station_latest_res.data[0]

--- a/custom_components/ims_envista/data.py
+++ b/custom_components/ims_envista/data.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .coordinator import ImsEnvistaUpdateCoordinator
 
 
-type ImsEnvistaConfigEntry = ConfigEntry[ImsEnvistaData]
+type ImsEnvistaConfigEntry = ConfigEntry
 
 
 @dataclass

--- a/custom_components/ims_envista/sensor.py
+++ b/custom_components/ims_envista/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -24,6 +24,7 @@ from homeassistant.const import (
 from .const import (
     BP_CHANNEL,
     DIFF_R_CHANNEL,
+    DOMAIN,
     GRAD_CHANNEL,
     LAST_UPDATED_CHANNEL,
     LATEST_KEY,
@@ -60,16 +61,20 @@ if TYPE_CHECKING:
     from ims_envista.station_data import StationInfo
 
     from .coordinator import ImsEnvistaUpdateCoordinator
-    from .data import ImsEnvistaConfigEntry
+    from .data import ImsEnvistaConfigEntry, ImsEnvistaData
 
 
 @dataclass(frozen=True, kw_only=True)
 class ImsEnvistaEntityDescriptionMixin:
     """Mixin values for required keys."""
 
-    value_fn: Callable[[dict | tuple | StationInfo], str | float | datetime] | None = (
-        None
-    )
+    value_fn: (
+        Callable[
+            [dict[str, Any] | tuple[Any, ...] | StationInfo],
+            str | float | datetime | None,
+        ]
+        | None
+    ) = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -84,14 +89,14 @@ ENTITY_DESCRIPTIONS = {
         key="station_name",
         name="Station Name",
         icon="mdi:home-city",
-        value_fn=lambda station_info: station_info.name.title(),
+        value_fn=lambda station_info: cast("StationInfo", station_info).name.title(),
     ),
     LAST_UPDATED_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="last_updated",
         device_class=SensorDeviceClass.TIMESTAMP,
         name="Last Update Time",
         icon="mdi:sun-clock",
-        value_fn=lambda data: data[LATEST_KEY].datetime,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].datetime,
     ),
     RAIN_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="rain",
@@ -100,7 +105,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="Rain",
         icon="mdi:weather-pouring",
-        value_fn=lambda data: data[LATEST_KEY].rain,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].rain,
     ),
     WSMAX_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="wsmax",
@@ -109,7 +114,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="WS Max",
         icon="mdi:weather-windy",
-        value_fn=lambda data: data[LATEST_KEY].ws_max,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].ws_max,
     ),
     WDMAX_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="wdmax",
@@ -117,7 +122,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=0,
         name="WD Max",
         icon="mdi:compass",
-        value_fn=lambda data: data[LATEST_KEY].wd_max,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].wd_max,
     ),
     WS_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="ws",
@@ -126,7 +131,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="WS",
         icon="mdi:weather-windy",
-        value_fn=lambda data: data[LATEST_KEY].ws,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].ws,
     ),
     WD_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="wd",
@@ -134,7 +139,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=0,
         name="WD",
         icon="mdi:compass",
-        value_fn=lambda data: data[LATEST_KEY].wd,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].wd,
     ),
     STDWD_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="std_wd",
@@ -142,7 +147,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="Std WD",
         icon="mdi:compass",
-        value_fn=lambda data: data[LATEST_KEY].std_wd,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].std_wd,
     ),
     TD_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="td",
@@ -151,7 +156,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="TD",
         icon="mdi:thermometer",
-        value_fn=lambda data: data[LATEST_KEY].td,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].td,
     ),
     TDMAX_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="td_max",
@@ -160,7 +165,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="TD max",
         icon="mdi:thermometer-chevron-up",
-        value_fn=lambda data: data[LATEST_KEY].td_max,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].td_max,
     ),
     TDMIN_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="td_min",
@@ -169,7 +174,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="TD Min",
         icon="mdi:thermometer-chevron-down",
-        value_fn=lambda data: data[LATEST_KEY].td_min,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].td_min,
     ),
     RH_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="rh",
@@ -178,7 +183,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=0,
         name="RH",
         icon="mdi:cloud-percent",
-        value_fn=lambda data: data[LATEST_KEY].rh,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].rh,
     ),
     TG_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="tg",
@@ -187,7 +192,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="TG",
         icon="mdi:thermometer",
-        value_fn=lambda data: data[LATEST_KEY].tg,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].tg,
     ),
     WS_1MM_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="ws_1mm",
@@ -196,7 +201,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="WS 1mm",
         icon="mdi:weather-windy",
-        value_fn=lambda data: data[LATEST_KEY].ws_1mm,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].ws_1mm,
     ),
     WS_10MM_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="ws_10mm",
@@ -205,7 +210,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="WS 10mm",
         icon="mdi:weather-windy",
-        value_fn=lambda data: data[LATEST_KEY].ws_10mm,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].ws_10mm,
     ),
     WS_10MM_LEGACY_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="ws_10mm",
@@ -214,7 +219,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="WS 10mm",
         icon="mdi:weather-windy",
-        value_fn=lambda data: data[LATEST_KEY].ws_10mm,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].ws_10mm,
     ),
     BP_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="bp",
@@ -223,7 +228,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="BP",
         icon="mdi:car-brake-low-pressure",
-        value_fn=lambda data: data[LATEST_KEY].bp,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].bp,
     ),
     DIFF_R_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="diff",
@@ -232,7 +237,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="DiffR",
         icon="mdi:radioactive",
-        value_fn=lambda data: data[LATEST_KEY].diff_r,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].diff_r,
     ),
     GRAD_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="grad",
@@ -241,7 +246,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="Grad",
         icon="mdi:radioactive-circle-outline",
-        value_fn=lambda data: data[LATEST_KEY].grad,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].grad,
     ),
     NIP_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="nip",
@@ -250,7 +255,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="NIP",
         icon="mdi:radioactive-circle",
-        value_fn=lambda data: data[LATEST_KEY].nip,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].nip,
     ),
     TIME_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="time",
@@ -259,9 +264,12 @@ ENTITY_DESCRIPTIONS = {
         name="Time",
         icon="mdi:timer-settings",
         value_fn=lambda data: (
-            datetime.combine(data[LATEST_KEY].datetime, data[LATEST_KEY].time)
-            if data[LATEST_KEY].time is not None
-            and data[LATEST_KEY].datetime is not None
+            datetime.combine(
+                cast("dict[str, Any]", data)[LATEST_KEY].datetime,
+                cast("dict[str, Any]", data)[LATEST_KEY].time,
+            )
+            if cast("dict[str, Any]", data)[LATEST_KEY].time is not None
+            and cast("dict[str, Any]", data)[LATEST_KEY].datetime is not None
             else None
         ),
     ),
@@ -272,7 +280,7 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="Rain 1 Min",
         icon="mdi:water",
-        value_fn=lambda data: data[LATEST_KEY].rain_1_min,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].rain_1_min,
     ),
     TW_CHANNEL: ImsEnvistaSensorEntityDescription(
         key="tw",
@@ -281,27 +289,30 @@ ENTITY_DESCRIPTIONS = {
         suggested_display_precision=1,
         name="TW",
         icon="mdi:thermometer",
-        value_fn=lambda data: data[LATEST_KEY].tw,
+        value_fn=lambda data: cast("dict[str, Any]", data)[LATEST_KEY].tw,
     ),
 }
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,  # noqa: ARG001 function argument: `hass`
+    hass: HomeAssistant,
     entry: ImsEnvistaConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    coordinator = entry.runtime_data.coordinator
-    station_id = entry.runtime_data.station_id
-    conditions = entry.runtime_data.conditions
+    entry_data = cast("ImsEnvistaData", hass.data[DOMAIN][entry.entry_id])
+    coordinator = entry_data.coordinator
+    station_id = entry_data.station_id
+    conditions = entry_data.conditions
 
     async_add_entities(
         ImsEnvistaSensor(
             coordinator=coordinator,
             station_id=station_id,
             condition_name=condition,
-            entity_description=ENTITY_DESCRIPTIONS.get(condition),
+            entity_description=cast(
+                "ImsEnvistaSensorEntityDescription", ENTITY_DESCRIPTIONS.get(condition)
+            ),
         )
         for condition in conditions
         if ENTITY_DESCRIPTIONS.get(condition)
@@ -317,6 +328,8 @@ async def async_setup_entry(
 class ImsEnvistaSensor(ImsEnvistaEntity, SensorEntity):
     """ims_envista Sensor class."""
 
+    entity_description: ImsEnvistaSensorEntityDescription
+
     def __init__(
         self,
         coordinator: ImsEnvistaUpdateCoordinator,
@@ -331,14 +344,17 @@ class ImsEnvistaSensor(ImsEnvistaEntity, SensorEntity):
         self._attr_translation_key = f"{entity_description.key}"
 
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> str | float | datetime | None:
         """Return the native value of the sensor."""
+        value_fn = self.entity_description.value_fn
+        if value_fn is None:
+            return None
         if self._condition_name in STATIC_DATA_CHANNELS:
-            return self.entity_description.value_fn(
-                self.coordinator.get_station_info(self._station_id)
-            )
+            station_info = self.coordinator.get_station_info(self._station_id)
+            if station_info is not None:
+                return value_fn(station_info)
         if self.coordinator.data is not None:
-            return self.entity_description.value_fn(
-                self.coordinator.data.get(self._station_id)
-            )
+            station_data = self.coordinator.data.get(self._station_id)
+            if station_data is not None:
+                return value_fn(station_data)
         return None

--- a/custom_components/ims_envista/weather.py
+++ b/custom_components/ims_envista/weather.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from homeassistant.components.weather import (
     ATTR_CONDITION_CLEAR_NIGHT,
@@ -20,26 +20,29 @@ from homeassistant.const import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    DOMAIN,
     LATEST_KEY,
 )
 from .coordinator import ImsEnvistaUpdateCoordinator
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
     from homeassistant.helpers.typing import DiscoveryInfoType
 
+    from .data import ImsEnvistaConfigEntry, ImsEnvistaData
+
 
 async def async_setup_entry(
-    hass: HomeAssistant,  # noqa: ARG001
-    config_entry: ConfigEntry,
+    hass: HomeAssistant,
+    config_entry: ImsEnvistaConfigEntry,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,  # noqa: ARG001
 ) -> None:
     """Set up IMS Weather entity based on a config entry."""
-    coordinator = config_entry.runtime_data.coordinator
-    station_id = config_entry.runtime_data.station_id
+    entry_data = cast("ImsEnvistaData", hass.data[DOMAIN][config_entry.entry_id])
+    coordinator = entry_data.coordinator
+    station_id = entry_data.station_id
     station = coordinator.get_station_info(station_id)
     station_name = station.name.title() if station is not None else str(station_id)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 colorlog>=6.8.2
 homeassistant==2024.2.0
 ims-envista==0.1.14
+mypy==1.20.0
 pip>=21.3.1
 ruff>=0.15.1

--- a/scripts/typecheck
+++ b/scripts/typecheck
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m mypy \
+    --cache-dir /tmp/mypy_cache_ims_envista \
+    --namespace-packages \
+    --explicit-package-bases \
+    --disable-error-code=import-untyped \
+    custom_components/ims_envista


### PR DESCRIPTION
Adds mypy to the type checking workflow, similar to PR https://github.com/GuyKh/iec-custom-component/pull/404

## Changes

- Add `mypy==1.20.0` to requirements.txt
- Create `scripts/typecheck` script for running mypy checks
- Add mypy job to `.github/workflows/lint.yml` CI workflow

## Type Fixes

Fixed type annotation issues in:
- **coordinator.py**: Added type annotations for class variables (`_stations`, `_stations_static_data`)
- **config_flow.py**: Fixed type errors with Optional types and proper dict annotations
- **sensor.py**: Added proper type hints with `cast()` and fixed return types to match callable signatures

All files now pass both mypy and ruff checks.